### PR TITLE
refactor: add in Parside

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,17 @@ ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
 indexmap = "~2.2.6"
 k256 = "~0.13.3"
 lazy_static = "~1.5.0"
+nom = "7.1.3"
+num-derive = "0.4.2"
+num-traits = "0.2.19"
 num-rational = "~0.4.2"
 p256 = "~0.13.2"
 rand_core = "~0.6.4"
 regex = "~1.10.5"
+rmp-serde = "1.3.0"
+serde = { version = "~1.0.204", features = ["derive"] }
 serde_json = { version = "~1.0.120", features = ["preserve_order"] }
+serde_cbor = "0.11.2"
 sha2 = "~0.10.8"
 sha3 = "~0.10.8"
 thiserror = "~1.0.62"

--- a/src/cesr/core/matter/tables.rs
+++ b/src/cesr/core/matter/tables.rs
@@ -101,6 +101,10 @@ pub(crate) fn raw_size(code: &str) -> Result<u32> {
     Ok((szg.fs - cs) * 3 / 4 - szg.ls)
 }
 
+/// Code table for the first letter of a matter code for cryptographic primitives.
+/// Example: (good example or bad? kind of doesn't make sense yet due to missing A for version)
+///   The primitive -AABAADjfOjbPu9OWce59OQIc-y3Su4kvfC2BAd_e_NLHbXcOK8-3s6do5vBfrxQ1kDyvFGCPMcSl620dLMZ4QDYlvME
+///   As the "D" in the code as it's first letter, following the AABAA for the protocol and genus.
 #[allow(non_snake_case)]
 #[allow(non_upper_case_globals)]
 pub mod Codex {

--- a/src/cesr/mod.rs
+++ b/src/cesr/mod.rs
@@ -1,11 +1,12 @@
 pub(crate) mod core;
 pub(crate) mod crypto;
+mod parside;
 
 pub use crate::cesr::core::{
     bexter::{Bext, Bexter},
     cigar::Cigar,
     common,
-    counter::{tables as counter, Counter}, // This seems like it shoudl be an abstract class
+    counter::{tables as counter, Counter}, // This seems like it should be an abstract class
     creder::Creder,
     dater::Dater,
     diger::Diger,

--- a/src/cesr/parside/README.md
+++ b/src/cesr/parside/README.md
@@ -1,0 +1,500 @@
+# parside
+
+[![parside](https://github.com/WebOfTrust/parside)](https://github.com/WebOfTrust/parside) code pulled in until we have
+a working agent
+
+Parser library for Composable Event Streaming Representation (CESR).
+
+This library is **currently under construction**.
+
+## Example
+
+Example parsing code (top level ACDC, KEL and TEL parsing):
+
+```rust
+    fn verify_acdc(&self, creder: &Creder, quadlets: &AttachedMaterialQuadlets, deep: Option<bool>) -> Result<bool> {
+        if creder.status()?.is_none() {
+            return err!(Error::Validation);
+        };
+
+        let vcid = creder.said()?;
+        let schema = creder.schema()?;
+        let prov = creder.chains()?;
+
+        let event = self.store.get_latest_transaction_event(&vcid)?;
+        let state = Serder::new_with_raw(event.as_bytes())?;
+        let dtnow = chrono::Utc::now();
+        let dte = chrono::DateTime::parse_from_rfc3339(&state.ked()["dt"].to_string()?)?.with_timezone(&chrono::Utc);
+        if (dtnow - dte).num_seconds() > Self::DEFAULT_CREDENTIAL_EXPIRY_SECONDS {
+            return err!(Error::Validation);
+        }
+
+        // added brv here for safety even though unimplemented
+        if [Ilkage::rev, Ilkage::brv].contains(&state.ked()[Ids::t].to_string()?.as_str()) {
+            return err!(Error::Validation);
+        }
+
+        schema_cache().verify(&schema, std::str::from_utf8(&creder.raw())?)?;
+
+        let mut rooted = false;
+
+        for group in quadlets.value() {
+            match group {
+                CesrGroup::SadPathSigVariant { value } => {
+                    for sad_path_sig in value.value() {
+                        if sad_path_sig.pather.bext()? != "-" {
+                            continue;
+                        }
+           
+                        rooted = true;
+           
+                        let event = self.store.get_key_event(&sad_path_sig.prefixer.qb64()?, sad_path_sig.seqner.sn()? as u32)?;
+                        let serder = Serder::new_with_raw(event.as_bytes())?;
+                        if serder.said()? != sad_path_sig.saider.qb64()? {
+                            return err!(Error::Verification)
+                        }
+           
+                        let verfers = serder.verfers()?;
+                        let mut sigers = vec![];
+                        for controller_idx_sig in sad_path_sig.sigers.value() {
+                            let siger = &controller_idx_sig.siger;
+                            if !sigers.contains(siger) {
+                                sigers.push(siger.clone())
+                            }
+                        }
+           
+                        let mut verified_indices = vec![];
+                        for siger in sigers {
+                            if siger.index() as usize > verfers.len() {
+                                return err!(Error::Verification);
+                            }
+           
+                            if verfers[siger.index() as usize].verify(&siger.raw(), &creder.raw())? {
+                                verified_indices.push(siger.index());
+                            }
+                        }
+           
+                        if let Some(tholder) = serder.tholder()? {
+                            if !tholder.satisfy(&verified_indices)? {
+                                return err!(Error::Verification);
+                            }
+                        } else {
+                            return err!(Error::Verification);
+                        }
+                    }                        
+                },
+                _ => return err!(Error::Decoding)
+            }
+        }
+
+        if !rooted {
+            return err!(Error::Verification);
+        }
+
+        let edges = if prov.to_map().is_ok() {
+            vec![prov]
+        } else if prov.to_vec().is_ok() {
+            prov.to_vec()?
+        } else {
+            return err!(Error::Verification);
+        };
+
+        for edge in &edges {
+            for (label, node) in edge.to_map()? {
+                if [Ids::d, "o"].contains(&label.as_str()) {
+                    continue;
+                }
+
+                let node_said = &node["n"].to_string()?;
+                let message = self.store.get_acdc(&node_said)?;
+
+                // here we need to default to true
+                if deep.unwrap_or(true) {
+                    let pacdc = Creder::new_with_raw(message.as_bytes())?;
+
+                    let (_, message_list) = MessageList::from_stream_bytes(message[pacdc.raw().len()..].as_bytes())?;
+                    let group = message_list.messages[0].cesr_group()?;
+
+                    match group {
+                        CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                            self.verify_acdc(&pacdc, value, deep)?;
+                        },
+                        _ => return err!(Error::Decoding)
+                    }
+                }
+            }
+        }
+
+        let result = self.store.get_acdc(&vcid);
+        let existing = result.is_ok();
+        if existing {
+            let message = result.unwrap();
+            let eacdc = Creder::new_with_raw(message.as_bytes())?;
+
+            // this seems very bad, it means something is in the database that shouldn't be there. how did it get there?
+            if vcid != eacdc.said()? {
+                return err!(Error::Programmer);
+            }
+        }
+
+        println!("succesfully verified acdc {vcid}");
+
+        Ok(existing)
+    }
+
+    fn verify_key_event(&self, serder: &Serder, quadlets: &AttachedMaterialQuadlets, deep: Option<bool>) -> Result<bool> {
+        let pre = serder.pre()?;
+        let ked = serder.ked();
+
+        // see if code is supported
+        let prefixer = Prefixer::new_with_qb64(&pre)?;
+
+        let sn = serder.sn()?;
+        let ilk = ked["t"].to_string()?;
+        let said = serder.said()?;
+
+        let mut existing = false;
+
+        let (verfers, tholder) = if serder.est()? {
+            let tholder = if let Some(tholder) = serder.tholder()? {
+                tholder
+            } else {
+                return err!(Error::Decoding);
+            };
+
+            (serder.verfers()?, tholder)
+        } else {
+            let (raw, _) = self.store.get_latest_establishment_event_as_of_sn(&pre, sn as u32 - 1)?;
+            let serder = Serder::new_with_raw(raw.as_bytes())?;
+
+            let tholder = if let Some(tholder) = serder.tholder()? {
+                tholder
+            } else {
+                return err!(Error::Decoding);
+            };
+
+            (serder.verfers()?, tholder)
+        };
+
+        let mut verified_indices = vec![0u32; 0];
+        for group in quadlets.value() {
+            match group {
+                CesrGroup::ControllerIdxSigsVariant { value } => {
+                    for controller_idx_sig in value.value() {
+                        let siger = &controller_idx_sig.siger;
+
+                        if siger.index() as usize > verfers.len() {
+                            return err!(Error::Verification);
+                        }
+   
+                        if verfers[siger.index() as usize].verify(&siger.raw(), &serder.raw())? {
+                            verified_indices.push(siger.index());
+                        }
+                    }
+                }
+                _ => return err!(Error::Decoding)
+            }
+        }
+
+        if !tholder.satisfy(&verified_indices)? {
+            return err!(Error::Verification);
+        }
+
+        let labels = match ilk.as_str() {
+            Ilkage::icp => &Self::ICP_LABELS,
+            Ilkage::rot => &Self::ROT_LABELS,
+            Ilkage::ixn => &Self::IXN_LABELS,
+            _ => return err!(Error::Decoding),
+        };
+        if !Self::verify_ked_labels(&ked, labels)? {
+            return err!(Error::Validation);
+        }
+
+        let inceptive = &ilk == Ilkage::icp;
+        let key_event_count = self.store.count_key_events(&pre)?;
+        if inceptive {
+            if !prefixer.verify(&serder.ked(), Some(true))? {
+                return err!(Error::Verification);
+            }
+
+            if sn != 0 {
+                // must be 0
+                return err!(Error::Decoding);
+            }
+
+            if said != serder.pre()? {
+                return err!(Error::Verification);
+            }
+
+            if key_event_count != 0 {
+                existing = true;
+            }
+        } else {
+            if !serder.saider().verify(&serder.ked(), Some(inceptive), Some(true), None, None, None)? {
+                return err!(Error::Verification);
+            }
+   
+            if sn < 1 {
+                return err!(Error::Validation);
+            }
+
+            let sno = key_event_count as u128;
+
+            if sn > sno {
+                // escrow here
+                return err!(Error::OutOfOrder);
+            }
+
+            if sn != sno {
+                existing = true;
+            }
+
+            // this sn implementation will become a problem at around 4 billion events
+            let event = self.store.get_key_event(&pre, sn as u32 - 1)?;
+            let pserder = Serder::new_with_raw(event.as_bytes())?;
+            if pserder.said()? != serder.ked()["p"].to_string()? {
+                return err!(Error::Verification);
+            }
+
+            if deep.unwrap_or(false) {
+                let (_, message_list) = MessageList::from_stream_bytes(event[pserder.raw().len()..].as_bytes())?;
+                let group = message_list.messages[0].cesr_group()?;
+
+                match group {
+                    CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                        self.verify_key_event(&pserder, value, deep)?;
+                    },
+                    _ => return err!(Error::Decoding)
+                }
+            }
+        }
+
+        if existing {
+            let event = self.store.get_key_event(&pre, sn as u32)?;
+            let eserder = Serder::new_with_raw(event.as_bytes())?;
+
+            // this seems very bad, it means something is in the database that shouldn't be there. how did it get there?
+            if said != eserder.said()? {
+                return err!(Error::Programmer);
+            }
+        }
+
+        println!("succesfully verified key event [{pre}, {said}]");
+       
+        Ok(existing)
+    }
+
+    fn verify_transaction_event(&self, serder: &Serder, seal_source_couples: &SealSourceCouples, deep: Option<bool>) -> Result<bool> {
+        let pre = serder.pre()?;
+        let ked = serder.ked();
+
+        // see if code is supported
+        let prefixer = Prefixer::new_with_qb64(&pre)?;
+
+        let sn = serder.sn()?;
+        let ilk = ked["t"].to_string()?;
+        let said = serder.said()?;
+        let ri = Self::extract_registry_from_serder(&ilk, &serder)?;
+
+        let mut existing = false;
+
+        if seal_source_couples.value.len() != 1 {
+            return err!(Error::Decoding);
+        }
+        let source_saider = &seal_source_couples.value()[0].saider;
+        let source_seqner = &seal_source_couples.value()[0].seqner;
+
+        let labels = match ilk.as_str() {
+            Ilkage::vcp => &Self::VCP_LABELS,
+            Ilkage::iss => &Self::ISS_LABELS,
+            Ilkage::rev => &Self::REV_LABELS,
+            _ => return err!(Error::Decoding),
+        };
+        if !Self::verify_ked_labels(&ked, labels)? {
+            return err!(Error::Validation);
+        }
+
+        let inceptive = &ilk == Ilkage::vcp || &ilk == Ilkage::iss;
+        let transaction_event_count = self.store.count_transaction_events(&pre)?;
+
+        let apre = match ilk.as_str() {
+            Ilkage::vcp => {
+                if !prefixer.verify(&ked, Some(true))? {
+                    return err!(Error::Verification);
+                }
+
+                ked["ii"].to_string()?
+            },
+            Ilkage::iss | Ilkage::rev => {
+                if !serder.saider().verify(&ked, Some(false), Some(true), None, None, None)? {
+                    return err!(Error::Verification);
+                }
+
+                let rievent = self.store.get_transaction_event(&ri, 0)?;
+                let riserder = Serder::new_with_raw(rievent.as_bytes())?;
+
+                riserder.ked()["ii"].to_string()?
+            },
+            _ => return err!(Error::Decoding)
+        };
+
+        if !self.verify_anchor(&apre, source_seqner, source_saider, serder, deep)? {
+            return err!(Error::Verification);
+        }
+
+        if inceptive {
+            if sn != 0 {
+                // must be 0
+                return err!(Error::Decoding);
+            }
+
+            if transaction_event_count != 0 {
+                existing = true;
+            }
+        } else {
+            if sn < 1 {
+                return err!(Error::Validation);
+            }
+
+            let sno = transaction_event_count as u128;
+
+            if sn > sno {
+                // escrow here
+                return err!(Error::OutOfOrder);
+            }
+
+            if sn != sno {
+                existing = true;
+            }
+
+            // this sn implementation will become a problem at around 4 billion events
+            let event = self.store.get_transaction_event(&pre, sn as u32 - 1)?;
+            let pserder = Serder::new_with_raw(event.as_bytes())?;
+
+            if deep.unwrap_or(false) {
+                let (_, message_list) = MessageList::from_stream_bytes(event[pserder.raw().len()..].as_bytes())?;
+                let group = message_list.messages[0].cesr_group()?;
+
+                match group {
+                    CesrGroup::SealSourceCouplesVariant { value } => {
+                        self.verify_transaction_event(&pserder, value, deep)?;
+                    },
+                    _ => return err!(Error::Decoding)
+                }
+            }
+
+            if pserder.said()? != serder.ked()["p"].to_string()? {
+                return err!(Error::Verification);
+            }
+        }
+
+        if existing {
+            let event = self.store.get_transaction_event(&pre, sn as u32)?;
+            let eserder = Serder::new_with_raw(event.as_bytes())?;
+
+            // this seems very bad, it means something is in the database that shouldn't be there. how did it get there?
+            if said != eserder.said()? {
+                return err!(Error::Programmer);
+            }
+        }
+
+        println!("succesfully verified transaction event [{pre}, {said}]");
+
+        Ok(existing)
+    }
+
+    pub fn ingest_messages(&mut self, messages: &str, deep: Option<bool>) -> Result<()> {
+        let (_, message_list) = MessageList::from_stream_bytes(messages.as_bytes())?;
+        let mut messages = message_list.messages.iter();
+
+        loop {
+            let sadder = messages.next();
+            if let Some(sadder) = sadder {
+                let payload = sadder.payload()?;
+                let raw_string = payload.value.to_string();
+                let raw_message = raw_string.as_bytes();
+                let result = cesride::common::sniff(raw_message)?;
+
+                if result.ident == Identage::KERI {
+                    let serder = Serder::new_with_raw(raw_message)?;
+
+                    let message = messages.next();
+                    if let Some(message) = message {
+                        let group = message.cesr_group()?;
+                        match serder.ked()["t"].to_string()?.as_str() {
+                            Ilkage::icp | Ilkage::rot | Ilkage::ixn => {                
+                                match group {
+                                    CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                                        let existing = self.verify_key_event(&serder, value, deep)?;
+                                        if !existing {
+                                            let event = String::from_utf8(serder.raw())? + &group.qb64()?;
+                                            self.store.insert_key_event(&serder.pre()?, &event)?;
+                                        }
+                                    },
+                                    _ => return err!(Error::Decoding), // we only accept pipelined input at present
+                                }
+                            },
+                            Ilkage::vcp | Ilkage::iss | Ilkage::rev => {
+                                match group {
+                                    CesrGroup::SealSourceCouplesVariant { value } => {
+                                        let existing = self.verify_transaction_event(&serder, value, deep)?;
+                                        if !existing {
+                                            let event = String::from_utf8(serder.raw())? + &group.qb64()?;
+                                            self.store.insert_transaction_event(&serder.pre()?, &event)?;
+                                        }
+                                    },
+                                    _ => return err!(Error::Decoding),
+                                }
+                            }
+                            _ => return err!(Error::Decoding),
+                        }
+                    } else {
+                        return err!(Error::Decoding);
+                    }
+                } else if result.ident == Identage::ACDC {
+                    let creder = Creder::new_with_raw(raw_message)?;
+
+                    let message = messages.next();
+                    if let Some(message) = message {
+                        let group = message.cesr_group()?;
+                        match group {
+                            CesrGroup::AttachedMaterialQuadletsVariant { value } => {
+                                let existing = self.verify_acdc(&creder, value, deep)?;
+                                if !existing {
+                                    let acdc = String::from_utf8(creder.raw())? + &group.qb64()?;
+                                    self.store.insert_acdc(&creder.said()?, &acdc)?;
+                                }
+                            },
+                            _ => return err!(Error::Decoding), // we only accept pipelined input at present
+                        };
+                    } else {
+                        return err!(Error::Decoding);
+                    }
+                } else {
+                    return err!(Error::Decoding)
+                }
+            } else {
+                break;
+            }
+        }
+
+        self.encrypt_and_cache_storage()
+    }
+```
+
+## Community
+
+Parside work currently resides alongside the [cesride](https://github.com/WebOfTrust/cesride) work.
+
+## Bi-weekly Meeting
+- [Zoom Link](https://us06web.zoom.us/j/88102305873?pwd=Wm01TEJKUWc0aE51a0QzZ2hNbTV2Zz09)
+- [HackMD Link](https://hackmd.io/UQaEI0w8Thy_xRF7oYX03Q?view) Bi-Weekly Meeting Agenda and Minutes
+- Slack https://join.slack.com/t/keriworld/shared_invite/zt-14326yxue-p7P~GEmAZ65luGSZvbgFAQ
+    - `#cesr` channel.
+
+# Important Reference Material
+- WebOfTrust/[ietf-cesr](https://github.com/WebOfTrust/ietf-cesr) repository - IETF draft specification for CESR
+- Design Assumptions, Use Cases, and ToDo list - [HackMD link](https://hackmd.io/W2Z39cuSSTmD2TovVLvAPg?view)
+- Introductory articles:
+    - [#1 CESR Proof Signatures](https://medium.com/happy-blockchains/cesr-proof-signatures-are-the-segwit-of-authentic-data-in-keri-e891c83e070a)
+    - [#2 CESR Overview](https://medium.com/happy-blockchains/cesr-one-of-sam-smiths-inventions-is-as-controversial-as-genius-d757f36b88f8)

--- a/src/cesr/parside/error/mod.rs
+++ b/src/cesr/parside/error/mod.rs
@@ -1,0 +1,37 @@
+use nom::error::ErrorKind;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ParsideError {
+    #[error("Payload deserialize error: {0}")]
+    PayloadDeserializeError(String),
+
+    #[error("Nom error")]
+    StreamDeserializationError(ErrorKind),
+
+    #[error("Empty bytes stream passed for parsing")]
+    EmptyBytesStream,
+
+    #[error("Requested variant does not exists")]
+    NotExist,
+
+    #[error("Unexpected variant")]
+    Unexpected(String),
+
+    #[error("Common error")]
+    Common(String),
+}
+
+impl<E> From<nom::Err<E>> for ParsideError {
+    fn from(_: nom::Err<E>) -> ParsideError {
+        ParsideError::StreamDeserializationError(ErrorKind::IsNot)
+    }
+}
+
+impl From<anyhow::Error> for ParsideError {
+    fn from(err: anyhow::Error) -> ParsideError {
+        ParsideError::Common(err.to_string())
+    }
+}
+
+pub type ParsideResult<T> = Result<T, ParsideError>;

--- a/src/cesr/parside/message/cold_code.rs
+++ b/src/cesr/parside/message/cold_code.rs
@@ -1,0 +1,39 @@
+use num_derive::{FromPrimitive, ToPrimitive};
+use num_traits::FromPrimitive;
+
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+
+/// Cold code defining the serialization format: https://weboftrust.github.io/ietf-cesr/draft-ssmith-cesr.html#section-3.6
+#[repr(u8)]
+#[derive(FromPrimitive, ToPrimitive, Debug, Clone)]
+pub(crate) enum ColdCode {
+    // not taken
+    Free = 0b000,
+    // CountCode Base64
+    CtB64 = 0b001,
+    // OpCode Base64
+    OpB64 = 0b010,
+    // JSON Map Event Start
+    Json = 0b011,
+    // MGPK Fixed Map Event Start
+    MGPK1 = 0b100,
+    // CBOR Map Event Start
+    Cbor = 0b101,
+    // MGPK Big 16 or 32 Map Event Start
+    MGPK2 = 0b110,
+    // CountCode or OpCode Base2
+    CtOpB2 = 0b111,
+}
+
+impl TryFrom<u8> for ColdCode {
+    type Error = ParsideError;
+
+    fn try_from(byte: u8) -> ParsideResult<Self> {
+        let tritet = byte >> 5;
+        FromPrimitive::from_u8(tritet).ok_or_else(|| {
+            ParsideError::PayloadDeserializeError(
+                "Unable to parse Message cold start code".to_string(),
+            )
+        })
+    }
+}

--- a/src/cesr/parside/message/custom_payload.rs
+++ b/src/cesr/parside/message/custom_payload.rs
@@ -1,0 +1,53 @@
+use rmp_serde as serde_mgpk;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use std::io::Cursor;
+
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+
+/// Datastructures representing custom payload
+#[derive(Debug)]
+pub struct CustomPayload {
+    pub value: JsonValue,
+}
+
+impl CustomPayload {
+    /// Convert custom payload to specific type
+    pub fn to_typed_message<D>(&self) -> ParsideResult<D>
+    where
+        D: DeserializeOwned,
+    {
+        serde_json::from_value::<D>(self.value.to_owned())
+            .map_err(|err| ParsideError::PayloadDeserializeError(err.to_string()))
+    }
+
+    /// Parse custom payload from JSON representation
+    pub(crate) fn from_json_stream(s: &[u8]) -> ParsideResult<(&[u8], CustomPayload)> {
+        let mut stream = serde_json::Deserializer::from_slice(s).into_iter::<JsonValue>();
+        match stream.next() {
+            Some(Ok(value)) => Ok((&s[stream.byte_offset()..], CustomPayload { value })),
+            Some(Err(err)) => Err(ParsideError::PayloadDeserializeError(err.to_string())),
+            None => Err(ParsideError::PayloadDeserializeError("End of stream".to_string())),
+        }
+    }
+
+    /// Parse custom payload from CBOR representation
+    pub(crate) fn from_cbor_stream(s: &[u8]) -> ParsideResult<(&[u8], CustomPayload)> {
+        let mut stream = serde_cbor::Deserializer::from_slice(s).into_iter::<JsonValue>();
+        match stream.next() {
+            Some(Ok(value)) => Ok((&s[stream.byte_offset()..], CustomPayload { value })),
+            Some(Err(err)) => Err(ParsideError::PayloadDeserializeError(err.to_string())),
+            None => Err(ParsideError::PayloadDeserializeError("End of stream".to_string())),
+        }
+    }
+
+    /// Parse custom payload from MessagePack representation
+    pub(crate) fn from_mgpk_stream(s: &[u8]) -> ParsideResult<(&[u8], CustomPayload)> {
+        let mut deser = serde_mgpk::Deserializer::new(Cursor::new(s));
+        match Deserialize::deserialize(&mut deser) {
+            Ok(value) => Ok((&s[deser.get_ref().position() as usize..], CustomPayload { value })),
+            Err(err) => Err(ParsideError::PayloadDeserializeError(err.to_string())),
+        }
+    }
+}

--- a/src/cesr/parside/message/groups/attached_material_quadlets.rs
+++ b/src/cesr/parside/message/groups/attached_material_quadlets.rs
@@ -1,0 +1,135 @@
+// use crate::error::ParsideResult;
+// use crate::message::cold_code::ColdCode;
+// use crate::message::{Group, GroupItem};
+// use crate::{nomify, CesrGroup};
+// use cesride::counter::Codex;
+// use cesride::Counter;
+use nom::multi::many0;
+use crate::cesr::Counter;
+use crate::cesr::counter::Codex;
+use crate::cesr::parside::{CesrGroup, Group};
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::GroupItem;
+use crate::nomify;
+
+#[derive(Debug, Clone, Default)]
+pub struct AttachedMaterialQuadlets {
+    pub value: Vec<CesrGroup>,
+}
+
+impl Group<CesrGroup> for AttachedMaterialQuadlets {
+    const CODE: &'static str = Codex::AttachedMaterialQuadlets;
+
+    fn new(value: Vec<CesrGroup>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<CesrGroup> {
+        &self.value
+    }
+}
+
+impl AttachedMaterialQuadlets {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        _counter: &Counter,
+        _cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], AttachedMaterialQuadlets)> {
+        let (rest, body) = many0(nomify!(CesrGroup::from_stream_bytes))(bytes)?;
+        Ok((rest, AttachedMaterialQuadlets { value: body }))
+    }
+}
+
+impl GroupItem for CesrGroup {
+    fn qb64(&self) -> ParsideResult<String> {
+        match self {
+            CesrGroup::ControllerIdxSigsVariant { value } => value.qb64(),
+            CesrGroup::WitnessIdxSigsVariant { value } => value.qb64(),
+            CesrGroup::NonTransReceiptCouplesVariant { value } => value.qb64(),
+            CesrGroup::TransReceiptQuadruplesVariant { value } => value.qb64(),
+            CesrGroup::TransIdxSigGroupsVariant { value } => value.qb64(),
+            CesrGroup::TransLastIdxSigGroupsVariant { value } => value.qb64(),
+            CesrGroup::FirstSeenReplayCouplesVariant { value } => value.qb64(),
+            CesrGroup::SealSourceCouplesVariant { value } => value.qb64(),
+            CesrGroup::AttachedMaterialQuadletsVariant { value } => value.qb64(),
+            CesrGroup::SadPathSigGroupVariant { value } => value.qb64(),
+            CesrGroup::SadPathSigVariant { value } => value.qb64(),
+            CesrGroup::PathedMaterialQuadletsVariant { value } => value.qb64(),
+        }
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        match self {
+            CesrGroup::ControllerIdxSigsVariant { value } => value.qb64b(),
+            CesrGroup::WitnessIdxSigsVariant { value } => value.qb64b(),
+            CesrGroup::NonTransReceiptCouplesVariant { value } => value.qb64b(),
+            CesrGroup::TransReceiptQuadruplesVariant { value } => value.qb64b(),
+            CesrGroup::TransIdxSigGroupsVariant { value } => value.qb64b(),
+            CesrGroup::TransLastIdxSigGroupsVariant { value } => value.qb64b(),
+            CesrGroup::FirstSeenReplayCouplesVariant { value } => value.qb64b(),
+            CesrGroup::SealSourceCouplesVariant { value } => value.qb64b(),
+            CesrGroup::AttachedMaterialQuadletsVariant { value } => value.qb64b(),
+            CesrGroup::SadPathSigGroupVariant { value } => value.qb64b(),
+            CesrGroup::SadPathSigVariant { value } => value.qb64b(),
+            CesrGroup::PathedMaterialQuadletsVariant { value } => value.qb64b(),
+        }
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        match self {
+            CesrGroup::ControllerIdxSigsVariant { value } => value.qb2(),
+            CesrGroup::WitnessIdxSigsVariant { value } => value.qb2(),
+            CesrGroup::NonTransReceiptCouplesVariant { value } => value.qb2(),
+            CesrGroup::TransReceiptQuadruplesVariant { value } => value.qb2(),
+            CesrGroup::TransIdxSigGroupsVariant { value } => value.qb2(),
+            CesrGroup::TransLastIdxSigGroupsVariant { value } => value.qb2(),
+            CesrGroup::FirstSeenReplayCouplesVariant { value } => value.qb2(),
+            CesrGroup::SealSourceCouplesVariant { value } => value.qb2(),
+            CesrGroup::AttachedMaterialQuadletsVariant { value } => value.qb2(),
+            CesrGroup::SadPathSigGroupVariant { value } => value.qb2(),
+            CesrGroup::SadPathSigVariant { value } => value.qb2(),
+            CesrGroup::PathedMaterialQuadletsVariant { value } => value.qb2(),
+        }
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        match self {
+            Self::ControllerIdxSigsVariant { value } => value.full_size(),
+            Self::WitnessIdxSigsVariant { value } => value.full_size(),
+            Self::NonTransReceiptCouplesVariant { value } => value.full_size(),
+            Self::TransReceiptQuadruplesVariant { value } => value.full_size(),
+            Self::TransIdxSigGroupsVariant { value } => value.full_size(),
+            Self::TransLastIdxSigGroupsVariant { value } => value.full_size(),
+            Self::FirstSeenReplayCouplesVariant { value } => value.full_size(),
+            Self::SealSourceCouplesVariant { value } => value.full_size(),
+            Self::AttachedMaterialQuadletsVariant { value } => value.full_size(),
+            Self::SadPathSigGroupVariant { value } => value.full_size(),
+            Self::SadPathSigVariant { value } => value.full_size(),
+            Self::PathedMaterialQuadletsVariant { value } => value.full_size(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::cesr::parside::message::groups::group::GroupItem;
+    // use crate::{CesrGroup, MessageList};
+
+    use crate::cesr::parside::{CesrGroup, MessageList};
+
+    #[test]
+    fn sanity() {
+        let quadlets = b"-VBj-JAB6AABAAA--FABEA_1ZGv4tEhJW2AYH0wLh2lLlllmH3dwpH3RGs2GtgXr0AAAAAAAAAAAAAAAAAAAAAAAEA_1ZGv4tEhJW2AYH0wLh2lLlllmH3dwpH3RGs2GtgXr-AADAABTqch8XeSwyCKFLV1I2OZLLXCCRvjdqiFkTmacYgc1ZgFoAXrUf5ME9IXjA9msTuswpbiKUW64_gW9C8gZCu8JABDRYWR7nw_MEnGE4FN0xmUL-5pVDRkPJGFMK9kcs3XLvQA5KNoMt1kREz4IsPVBgE4ltE44F-6oQ6TYtaoSwb4OACDsl4VeiqrIk9EMy6E58dNao3J2SQJRAmVNgvF7I3t1Uf7ZJ_bOLcouvlcyq46FcpDCL2SmVSuW-ITsbgjz_uwJ";
+        let (_, message_list) = MessageList::from_stream_bytes(quadlets).unwrap();
+
+        let message = message_list.messages.first().unwrap();
+        let group = message.cesr_group().unwrap();
+        match group {
+            CesrGroup::AttachedMaterialQuadletsVariant { value: _ } => {
+                assert_eq!(group.qb64().unwrap(), String::from_utf8(quadlets.to_vec()).unwrap());
+            }
+            _ => panic!("this shouldn't happen"),
+        }
+    }
+}

--- a/src/cesr/parside/message/groups/controller_idx_sigs.rs
+++ b/src/cesr/parside/message/groups/controller_idx_sigs.rs
@@ -1,0 +1,94 @@
+// use crate::error::{ParsideError, ParsideResult};
+// use crate::message::cold_code::ColdCode;
+// use crate::message::parsers::Parsers;
+// use crate::message::{Group, GroupItem};
+// use cesride::counter::Codex as CounterCodex;
+// use cesride::{Counter, Indexer, Siger};
+use nom::multi::count;
+use crate::cesr::{Counter, Indexer, Siger};
+use crate::cesr::counter::Codex;
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::Group;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::GroupItem;
+use crate::cesr::parside::message::parsers::Parsers;
+
+#[derive(Debug, Clone, Default)]
+pub struct ControllerIdxSigs {
+    pub value: Vec<ControllerIdxSig>,
+}
+
+impl Group<ControllerIdxSig> for ControllerIdxSigs {
+    const CODE: &'static str = Codex::ControllerIdxSigs;
+
+    fn new(value: Vec<ControllerIdxSig>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<ControllerIdxSig> {
+        &self.value
+    }
+}
+
+impl ControllerIdxSigs {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], ControllerIdxSigs)> {
+        let (rest, body) =
+            count(Parsers::siger_parser(cold_code)?, counter.count() as usize)(bytes)?;
+        let body = body.into_iter().map(|siger| ControllerIdxSig { siger }).collect();
+        Ok((rest, ControllerIdxSigs { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ControllerIdxSig {
+    pub siger: Siger,
+}
+
+impl ControllerIdxSig {
+    pub fn new(siger: Siger) -> Self {
+        Self { siger }
+    }
+}
+
+impl GroupItem for ControllerIdxSig {
+    fn qb64(&self) -> ParsideResult<String> {
+        self.siger.qb64().map_err(ParsideError::from)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb64b().map_err(ParsideError::from)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb2().map_err(ParsideError::from)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.siger.full_size()?;
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::cesr::matter::Codex as MatterCodex;
+
+    #[test]
+    pub fn test_parse_controller_idx_sigs() {
+        let stream = br#"AABg3q8uNg1A2jhEAdbKGf-QupQhNnmZQx3zIyPLWBe6qqLT5ynytivf9EwJhxyhy87a0x2cezDdil4SsM2xxs0O"#;
+
+        let counter =
+            Counter::new(Some(1), None, Some(ControllerIdxSigs::CODE), None, None, None).unwrap();
+        let (rest, group) =
+            ControllerIdxSigs::from_stream_bytes(stream, &counter, &ColdCode::CtB64).unwrap();
+
+        assert!(rest.is_empty());
+        assert_eq!(1, group.value.len());
+        assert_eq!(MatterCodex::Ed25519_Seed.to_string(), group.value[0].siger.code());
+    }
+}

--- a/src/cesr/parside/message/groups/first_seen_replay_couples.rs
+++ b/src/cesr/parside/message/groups/first_seen_replay_couples.rs
@@ -1,0 +1,96 @@
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex as CounterCodex;
+use crate::cesr::{Counter, Dater, Matter, Seqner};
+use nom::multi::count;
+use nom::sequence::tuple;
+
+#[derive(Debug, Clone, Default)]
+pub struct FirstSeenReplayCouples {
+    pub value: Vec<FirstSeenReplayCouple>,
+}
+
+impl Group<FirstSeenReplayCouple> for FirstSeenReplayCouples {
+    const CODE: &'static str = CounterCodex::FirstSeenReplayCouples;
+
+    fn new(value: Vec<FirstSeenReplayCouple>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<FirstSeenReplayCouple> {
+        &self.value
+    }
+}
+
+impl FirstSeenReplayCouples {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], FirstSeenReplayCouples)> {
+        let (rest, body) = count(
+            tuple((Parsers::seqner_parser(cold_code)?, Parsers::dater_parser(cold_code)?)),
+            counter.count() as usize,
+        )(bytes)?;
+        let body = body
+            .into_iter()
+            .map(|(firner, dater)| FirstSeenReplayCouple { firner, dater })
+            .collect();
+
+        Ok((rest, FirstSeenReplayCouples { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FirstSeenReplayCouple {
+    pub firner: Seqner,
+    pub dater: Dater,
+}
+
+impl FirstSeenReplayCouple {
+    pub fn new(firner: Seqner, dater: Dater) -> Self {
+        Self { firner, dater }
+    }
+}
+
+impl GroupItem for FirstSeenReplayCouple {
+    fn qb64(&self) -> ParsideResult<String> {
+        let mut out = "\0".repeat(self.full_size()?);
+        let mut offset = 0;
+        let mut len = self.dater.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }.copy_from_slice(self.dater.qb64()?.as_bytes());
+        offset += len;
+        len = self.firner.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }.copy_from_slice(self.firner.qb64()?.as_bytes());
+        Ok(out)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()?];
+        let mut offset = 0;
+        let mut len = self.dater.full_size()?;
+        out[offset..len].copy_from_slice(&self.dater.qb64b()?);
+        offset += len;
+        len = self.firner.full_size()?;
+        out[offset..len].copy_from_slice(&self.firner.qb64b()?);
+        Ok(out)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()? / 4 * 3];
+        let mut offset = 0;
+        let mut len = self.dater.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.dater.qb2()?);
+        offset += len;
+        len = self.firner.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.firner.qb2()?);
+        Ok(out)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.dater.full_size()? + self.firner.full_size()?;
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/groups/group.rs
+++ b/src/cesr/parside/message/groups/group.rs
@@ -1,0 +1,82 @@
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::{counter::Codex, Counter};
+
+pub trait Group<T: GroupItem> {
+    /// Code associated with the group
+    const CODE: &'static str;
+
+    /// Group constructor
+    fn new(value: Vec<T>) -> Self;
+
+    /// Get group values
+    fn value(&self) -> &Vec<T>;
+
+    /// Get group counter
+    fn counter(&self) -> ParsideResult<Counter> {
+        Counter::new_with_code_and_count(Self::CODE, self.count()?).map_err(ParsideError::from)
+    }
+
+    /// Get count of items in the group
+    fn count(&self) -> ParsideResult<u32> {
+        match Self::CODE {
+            Codex::AttachedMaterialQuadlets | Codex::BigAttachedMaterialQuadlets => {
+                Ok(self.full_size()? as u32 / 4 - 1)
+            }
+            _ => Ok(self.value().len() as u32),
+        }
+    }
+
+    /// Get qb64 representation of the group
+    fn qb64(&self) -> ParsideResult<String> {
+        let mut out = self.counter()?.qb64()?;
+        for value in self.value().iter() {
+            out.push_str(&value.qb64()?);
+        }
+        Ok(out)
+    }
+
+    /// Get qb64b representation of the group
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = self.counter()?.qb64b()?;
+        for value in self.value().iter() {
+            out.extend_from_slice(&value.qb64b()?);
+        }
+        Ok(out)
+    }
+
+    /// Get qb2 representation of the group
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = self.counter()?.qb2()?;
+        for value in self.value().iter() {
+            out.extend_from_slice(&value.qb2()?);
+        }
+        Ok(out)
+    }
+
+    /// Get total size of the group
+    fn full_size(&self) -> ParsideResult<usize> {
+        let mut size = match Self::CODE {
+            Codex::AttachedMaterialQuadlets | Codex::BigAttachedMaterialQuadlets => 4usize,
+            _ => self.counter()?.full_size()?,
+        };
+
+        for value in self.value().iter() {
+            size += value.full_size()?;
+        }
+        Ok(size)
+    }
+}
+
+pub trait GroupItem {
+    /// Get qb64 representation of the group item
+    fn qb64(&self) -> ParsideResult<String>;
+
+    /// Get qb64b representation of the group item
+    fn qb64b(&self) -> ParsideResult<Vec<u8>>;
+
+    /// Get qb2 representation of the group item
+    fn qb2(&self) -> ParsideResult<Vec<u8>>;
+
+    /// Get total size of the group item
+    fn full_size(&self) -> ParsideResult<usize>;
+}

--- a/src/cesr/parside/message/groups/mod.rs
+++ b/src/cesr/parside/message/groups/mod.rs
@@ -1,0 +1,224 @@
+#![allow(unused_imports)]
+
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+
+pub use self::attached_material_quadlets::AttachedMaterialQuadlets;
+pub use self::controller_idx_sigs::{ControllerIdxSig, ControllerIdxSigs};
+pub use self::first_seen_replay_couples::{FirstSeenReplayCouple, FirstSeenReplayCouples};
+pub use self::group::{Group, GroupItem};
+pub use self::non_trans_receipt_couples::{NonTransReceiptCouple, NonTransReceiptCouples};
+pub use self::pathed_material_quadlets::{PathedMaterialQuadlet, PathedMaterialQuadlets};
+pub use self::sad_path_sig::{SadPathSig, SadPathSigs};
+pub use self::sad_path_sig_group::{SadPathSigGroup, SadPathSigGroups};
+pub use self::seal_source_couples::{SealSourceCouple, SealSourceCouples};
+pub use self::trans_idx_sig_groups::{TransIdxSigGroup, TransIdxSigGroups};
+pub use self::trans_last_idx_sig_groups::{TransLastIdxSigGroup, TransLastIdxSigGroups};
+pub use self::trans_receipt_quadruples::{TransReceiptQuadruple, TransReceiptQuadruples};
+pub use self::witness_idx_sigs::{WitnessIdxSig, WitnessIdxSigs};
+
+pub mod attached_material_quadlets;
+pub mod controller_idx_sigs;
+pub mod first_seen_replay_couples;
+pub mod group;
+pub mod non_trans_receipt_couples;
+pub mod pathed_material_quadlets;
+pub mod sad_path_sig;
+pub mod sad_path_sig_group;
+pub mod seal_source_couples;
+pub mod trans_idx_sig_groups;
+pub mod trans_last_idx_sig_groups;
+pub mod trans_receipt_quadruples;
+pub mod witness_idx_sigs;
+
+/// Datastructures representing known CESR group
+#[derive(Debug, Clone)]
+pub enum CesrGroup {
+    ControllerIdxSigsVariant { value: ControllerIdxSigs },
+    WitnessIdxSigsVariant { value: WitnessIdxSigs },
+    NonTransReceiptCouplesVariant { value: NonTransReceiptCouples },
+    TransReceiptQuadruplesVariant { value: TransReceiptQuadruples },
+    TransIdxSigGroupsVariant { value: TransIdxSigGroups },
+    TransLastIdxSigGroupsVariant { value: TransLastIdxSigGroups },
+    FirstSeenReplayCouplesVariant { value: FirstSeenReplayCouples },
+    SealSourceCouplesVariant { value: SealSourceCouples },
+    AttachedMaterialQuadletsVariant { value: AttachedMaterialQuadlets },
+    SadPathSigGroupVariant { value: SadPathSigGroups },
+    SadPathSigVariant { value: SadPathSigs },
+    PathedMaterialQuadletsVariant { value: PathedMaterialQuadlets },
+}
+
+impl CesrGroup {
+    /// Parse CESR group from bytes
+    pub fn from_stream_bytes(bytes: &[u8]) -> ParsideResult<(&[u8], CesrGroup)> {
+        if bytes.is_empty() {
+            return Err(ParsideError::EmptyBytesStream);
+        }
+
+        let cold_code = ColdCode::try_from(bytes[0])?;
+        let (rest, counter) = Parsers::counter_parser(&cold_code)?(bytes)?;
+        match counter.code().as_str() {
+            AttachedMaterialQuadlets::CODE => {
+                let (rest, group) =
+                    AttachedMaterialQuadlets::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::AttachedMaterialQuadletsVariant { value: group }))
+            }
+            ControllerIdxSigs::CODE => {
+                let (rest, group) =
+                    ControllerIdxSigs::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::ControllerIdxSigsVariant { value: group }))
+            }
+            WitnessIdxSigs::CODE => {
+                let (rest, group) = WitnessIdxSigs::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::WitnessIdxSigsVariant { value: group }))
+            }
+            NonTransReceiptCouples::CODE => {
+                let (rest, group) =
+                    NonTransReceiptCouples::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::NonTransReceiptCouplesVariant { value: group }))
+            }
+            TransReceiptQuadruples::CODE => {
+                let (rest, group) =
+                    TransReceiptQuadruples::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::TransReceiptQuadruplesVariant { value: group }))
+            }
+            TransIdxSigGroups::CODE => {
+                let (rest, group) =
+                    TransIdxSigGroups::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::TransIdxSigGroupsVariant { value: group }))
+            }
+            TransLastIdxSigGroups::CODE => {
+                let (rest, group) =
+                    TransLastIdxSigGroups::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::TransLastIdxSigGroupsVariant { value: group }))
+            }
+            FirstSeenReplayCouples::CODE => {
+                let (rest, group) =
+                    FirstSeenReplayCouples::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::FirstSeenReplayCouplesVariant { value: group }))
+            }
+            SealSourceCouples::CODE => {
+                let (rest, group) =
+                    SealSourceCouples::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::SealSourceCouplesVariant { value: group }))
+            }
+            SadPathSigGroups::CODE => {
+                let (rest, group) =
+                    SadPathSigGroups::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::SadPathSigGroupVariant { value: group }))
+            }
+            SadPathSigs::CODE => {
+                let (rest, group) = SadPathSigs::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::SadPathSigVariant { value: group }))
+            }
+            PathedMaterialQuadlets::CODE => {
+                let (rest, group) =
+                    PathedMaterialQuadlets::from_stream_bytes(rest, &counter, &cold_code)?;
+                Ok((rest, CesrGroup::PathedMaterialQuadletsVariant { value: group }))
+            }
+            _ => Err(ParsideError::Unexpected(format!(
+                "Unexpected counter code {:?}",
+                counter.code()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::cesr::{Indexer, Matter};
+    pub use crate::cesr::matter::Codex as MatterCodex;
+
+    use super::*;
+
+    #[test]
+    pub fn test_parse_trans_idx_sig_groups() {
+        let stream = br#"-FABEFhg5my9DuMU6gw1CVk6QgkmZKBttWSXDzVzWVmxh0_K0AAAAAAAAAAAAAAAAAAAAAAAEFhg5my9DuMU6gw1CVk6QgkmZKBttWSXDzVzWVmxh0_K-AABAADghKct9eYTuSgSd5wdPSYG06tGX7ZRp_BDnrgbSxJpsJtrA-fP7Pa1W602gHeMrO6HZsD1z3tWV5jGlApFmVIB"#;
+        let (rest, group) = CesrGroup::from_stream_bytes(stream).unwrap();
+        assert!(rest.is_empty());
+        match group {
+            CesrGroup::TransIdxSigGroupsVariant { value: group } => {
+                assert_eq!(1, group.value.len());
+                assert_eq!(MatterCodex::Blake3_256.to_string(), group.value[0].prefixer.code());
+                assert_eq!(MatterCodex::Salt_128.to_string(), group.value[0].seqner.code());
+                assert_eq!(MatterCodex::Blake3_256.to_string(), group.value[0].saider.code());
+            }
+            _ => panic!("Unexpected case"),
+        }
+    }
+
+    #[test]
+    pub fn test_parse_controller_idx_sigs() {
+        let stream = br#"-AABAABg3q8uNg1A2jhEAdbKGf-QupQhNnmZQx3zIyPLWBe6qqLT5ynytivf9EwJhxyhy87a0x2cezDdil4SsM2xxs0O"#;
+        let (rest, group) = CesrGroup::from_stream_bytes(stream).unwrap();
+        assert!(rest.is_empty());
+        match group {
+            CesrGroup::ControllerIdxSigsVariant { value: group } => {
+                assert_eq!(1, group.value.len());
+                assert_eq!(MatterCodex::Ed25519_Seed.to_string(), group.value[0].siger.code());
+            }
+            _ => panic!("Unexpected case"),
+        }
+    }
+
+    #[test]
+    pub fn test_parse_non_trans_receipt_couples() {
+        let stream = br#"-CABBD8-gMSJ6K1PQ7_gG5ZJn2NkHQJgdkiNrTBz_FWWS_cC0BDc1i44ZX0jaIHh5oNDx-TITbPnI6VEn2nKlqPwkkTF452X7XxYh80tolDpReYwZpnD8TF4Or2v3CpSCikyt6EG"#;
+        let (rest, group) = CesrGroup::from_stream_bytes(stream).unwrap();
+        assert!(rest.is_empty());
+        match group {
+            CesrGroup::NonTransReceiptCouplesVariant { value: group } => {
+                assert_eq!(1, group.value.len());
+                assert_eq!(MatterCodex::Ed25519_Sig.to_string(), group.value[0].cigar.code());
+            }
+            _ => panic!("Unexpected case"),
+        }
+    }
+
+    #[test]
+    pub fn test_parse_attached_material_quadlets() {
+        let stream = br#"-VA--AABAAAEmCc25ETG2m1Ya-tPGuEqsPywOtusQwXKy076ve56IHXzX2bs0xsdQ4dk0XsanstpThg71ynIy-yUDSue6jMD-BABAABfvC7zCIVOVMol9C4AlSALS9JhL8PCdfgRnJgkXG4U11gFyZbsI_J828POrtwtoOmFhs20hoH1pYw4NZr2cdwN-EAB0AAAAAAAAAAAAAAAAAAAAAAE1AAG2023-02-07T15c00c00d025640p00c00"#;
+        let (rest, message) = CesrGroup::from_stream_bytes(stream).unwrap();
+        assert!(rest.is_empty());
+        match message {
+            CesrGroup::AttachedMaterialQuadletsVariant { value: group } => {
+                assert_eq!(3, group.value.len());
+                assert!(matches!(
+                    group.value.get(0).cloned().unwrap(),
+                    CesrGroup::ControllerIdxSigsVariant { .. }
+                ));
+                assert!(matches!(
+                    group.value.get(1).cloned().unwrap(),
+                    CesrGroup::WitnessIdxSigsVariant { .. }
+                ));
+                assert!(matches!(
+                    group.value.get(2).cloned().unwrap(),
+                    CesrGroup::FirstSeenReplayCouplesVariant { .. }
+                ));
+            }
+            _ => panic!("Unexpected case"),
+        }
+    }
+
+    #[test]
+    pub fn test_parse_trans_last_idx_sig_groups() {
+        let stream = br#"-HABEB1f36VmoizOIpBIBv3X4ZiWJQWjtKJ7TMmsZltT0B32-AABAAAKB9u6wyLS9kl_iGVGCqrs-3XqFbyGeOKuiOEA9JZpxI9GMv0GJv2wbY1-sOD_HOJcvXO7LSO8g8MSeRXjtL4I"#;
+        let (rest, group) = CesrGroup::from_stream_bytes(stream).unwrap();
+        assert!(rest.is_empty());
+        match group {
+            CesrGroup::TransLastIdxSigGroupsVariant { value: group } => {
+                assert_eq!(1, group.value.len());
+                assert_eq!(MatterCodex::Blake3_256.to_string(), group.value[0].prefixer.code());
+            }
+            _ => panic!("Unexpected case"),
+        }
+    }
+
+    #[test]
+    pub fn test_parse_when_there_is_enough_group_bytes() {
+        let stream = br#"-FABEFhg5my9DuMU6gw1CVk6QgkmZKBttWS"#;
+        let err = CesrGroup::from_stream_bytes(stream).unwrap_err();
+        assert!(matches!(err, ParsideError::StreamDeserializationError(..)));
+    }
+}

--- a/src/cesr/parside/message/groups/non_trans_receipt_couples.rs
+++ b/src/cesr/parside/message/groups/non_trans_receipt_couples.rs
@@ -1,0 +1,87 @@
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Cigar, Counter, Matter};
+use nom::multi::count;
+
+#[derive(Debug, Clone, Default)]
+pub struct NonTransReceiptCouples {
+    pub value: Vec<NonTransReceiptCouple>,
+}
+
+impl Group<NonTransReceiptCouple> for NonTransReceiptCouples {
+    const CODE: &'static str = Codex::NonTransReceiptCouples;
+
+    fn new(value: Vec<NonTransReceiptCouple>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<NonTransReceiptCouple> {
+        &self.value
+    }
+}
+
+impl NonTransReceiptCouples {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], NonTransReceiptCouples)> {
+        let (rest, body) =
+            count(Parsers::cigar_parser(cold_code)?, counter.count() as usize)(bytes)?;
+        let body = body.into_iter().map(|cigar| NonTransReceiptCouple { cigar }).collect();
+        Ok((rest, NonTransReceiptCouples { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NonTransReceiptCouple {
+    pub cigar: Cigar,
+}
+
+impl NonTransReceiptCouple {
+    pub fn new(cigar: Cigar) -> Self {
+        Self { cigar }
+    }
+}
+
+impl GroupItem for NonTransReceiptCouple {
+    fn qb64(&self) -> ParsideResult<String> {
+        self.cigar.qb64().map_err(ParsideError::from)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        self.cigar.qb64b().map_err(ParsideError::from)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        self.cigar.qb2().map_err(ParsideError::from)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.cigar.full_size()?;
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    pub use crate::cesr::matter::Codex as MatterCodex;
+
+    #[test]
+    pub fn test_parse_non_trans_receipt_couples() {
+        let stream = br#"BD8-gMSJ6K1PQ7_gG5ZJn2NkHQJgdkiNrTBz_FWWS_cC0BDc1i44ZX0jaIHh5oNDx-TITbPnI6VEn2nKlqPwkkTF452X7XxYh80tolDpReYwZpnD8TF4Or2v3CpSCikyt6EG"#;
+
+        let counter =
+            Counter::new(Some(1), None, Some(NonTransReceiptCouples::CODE), None, None, None)
+                .unwrap();
+        let (rest, group) =
+            NonTransReceiptCouples::from_stream_bytes(stream, &counter, &ColdCode::CtB64).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(1, group.value.len());
+        assert_eq!(MatterCodex::Ed25519_Sig.to_string(), group.value[0].cigar.code());
+    }
+}

--- a/src/cesr/parside/message/groups/pathed_material_quadlets.rs
+++ b/src/cesr/parside/message/groups/pathed_material_quadlets.rs
@@ -1,0 +1,63 @@
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Indexer, Siger};
+
+// FIXME: Implement proper definition
+#[derive(Debug, Clone, Default)]
+pub struct PathedMaterialQuadlets {
+    pub value: Vec<PathedMaterialQuadlet>,
+}
+
+impl Group<PathedMaterialQuadlet> for PathedMaterialQuadlets {
+    const CODE: &'static str = Codex::PathedMaterialQuadlets;
+
+    fn new(value: Vec<PathedMaterialQuadlet>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<PathedMaterialQuadlet> {
+        &self.value
+    }
+}
+
+impl PathedMaterialQuadlets {
+    pub(crate) fn from_stream_bytes<'a>(
+        _bytes: &'a [u8],
+        _counter: &Counter,
+        _cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], PathedMaterialQuadlets)> {
+        unimplemented!();
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PathedMaterialQuadlet {
+    pub siger: Siger,
+}
+
+impl PathedMaterialQuadlet {
+    pub fn new(siger: Siger) -> Self {
+        Self { siger }
+    }
+}
+
+impl GroupItem for PathedMaterialQuadlet {
+    fn qb64(&self) -> ParsideResult<String> {
+        self.siger.qb64().map_err(ParsideError::from)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb64b().map_err(ParsideError::from)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb2().map_err(ParsideError::from)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.siger.full_size()?;
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/groups/sad_path_sig.rs
+++ b/src/cesr/parside/message/groups/sad_path_sig.rs
@@ -1,0 +1,149 @@
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Matter, Saider, Seqner};
+use nom::multi::count;
+use nom::sequence::tuple;
+use crate::pathing::pather::Pather;
+use crate::prefexing::prefixer::Prefixer;
+use super::{ControllerIdxSig, ControllerIdxSigs};
+
+// FIXME: Implement proper definition
+#[derive(Debug, Clone, Default)]
+pub struct SadPathSigs {
+    pub value: Vec<SadPathSig>,
+}
+
+impl Group<SadPathSig> for SadPathSigs {
+    const CODE: &'static str = Codex::SadPathSig;
+
+    fn new(value: Vec<SadPathSig>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<SadPathSig> {
+        &self.value
+    }
+}
+
+impl SadPathSigs {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], SadPathSigs)> {
+        let (rest, body) = count(
+            tuple((
+                Parsers::pather_parser(cold_code)?,
+                Parsers::counter_parser(cold_code)?,
+                Parsers::prefixer_parser(cold_code)?,
+                Parsers::seqner_parser(cold_code)?,
+                Parsers::saider_parser(cold_code)?,
+                Parsers::siger_list_parser(cold_code)?,
+            )),
+            counter.count() as usize,
+        )(bytes)?;
+
+        let body = body
+            .into_iter()
+            .map(|(pather, tcounter, prefixer, seqner, saider, sigers)| SadPathSig {
+                pather,
+                tcounter,
+                prefixer,
+                seqner,
+                saider,
+                sigers: ControllerIdxSigs::new(
+                    sigers.into_iter().map(ControllerIdxSig::new).collect(),
+                ),
+            })
+            .collect();
+
+        Ok((rest, SadPathSigs { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SadPathSig {
+    pub pather: Pather,
+    pub tcounter: Counter,
+    pub prefixer: Prefixer,
+    pub seqner: Seqner,
+    pub saider: Saider,
+    pub sigers: ControllerIdxSigs,
+}
+
+impl GroupItem for SadPathSig {
+    fn qb64(&self) -> ParsideResult<String> {
+        let mut out = String::new();
+
+        out += &self.pather.qb64()?;
+        out += &self.tcounter.qb64()?;
+        out += &self.prefixer.qb64()?;
+        out += &self.seqner.qb64()?;
+        out += &self.saider.qb64()?;
+        out += &self.sigers.qb64()?;
+
+        Ok(out)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()?];
+        let mut offset = 0;
+        let mut len = self.pather.full_size()?;
+        out[offset..offset + len].copy_from_slice(&self.pather.qb64b()?);
+        offset += len;
+        len = self.tcounter.full_size()?;
+        out[offset..offset + len].copy_from_slice(&self.tcounter.qb64b()?);
+        offset += len;
+        len = self.prefixer.full_size()?;
+        out[offset..offset + len].copy_from_slice(&self.prefixer.qb64b()?);
+        offset += len;
+        len = self.seqner.full_size()?;
+        out[offset..offset + len].copy_from_slice(&self.seqner.qb64b()?);
+        offset += len;
+        len = self.saider.full_size()?;
+        out[offset..offset + len].copy_from_slice(&self.saider.qb64b()?);
+        offset += len;
+        len = self.sigers.full_size()?;
+        out[offset..offset + len].copy_from_slice(&self.sigers.qb64b()?);
+        Ok(out)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()? / 4 * 3];
+        let mut offset = 0;
+        let mut len = self.pather.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.pather.qb2()?);
+        offset += len;
+        len = self.tcounter.full_size()? / 4 * 3;
+        out[offset..offset + len].copy_from_slice(&self.tcounter.qb2()?);
+        offset += len;
+        len = self.prefixer.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.prefixer.qb2()?);
+        offset += len;
+        len = self.seqner.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.seqner.qb2()?);
+        offset += len;
+        len = self.saider.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.saider.qb2()?);
+        offset += len;
+        len = self.sigers.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.sigers.qb2()?);
+        Ok(out)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let mut size = 0usize;
+
+        size += self.pather.full_size()?;
+        size += self.tcounter.full_size()?;
+        size += self.prefixer.full_size()?;
+        size += self.seqner.full_size()?;
+        size += self.saider.full_size()?;
+        size += self.sigers.full_size()?;
+
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/groups/sad_path_sig_group.rs
+++ b/src/cesr/parside/message/groups/sad_path_sig_group.rs
@@ -1,0 +1,63 @@
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Indexer, Siger};
+
+// FIXME: Implement proper definition
+#[derive(Debug, Clone, Default)]
+pub struct SadPathSigGroups {
+    pub value: Vec<SadPathSigGroup>,
+}
+
+impl Group<SadPathSigGroup> for SadPathSigGroups {
+    const CODE: &'static str = Codex::SadPathSigGroup;
+
+    fn new(value: Vec<SadPathSigGroup>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<SadPathSigGroup> {
+        &self.value
+    }
+}
+
+impl SadPathSigGroups {
+    pub(crate) fn from_stream_bytes<'a>(
+        _bytes: &'a [u8],
+        _counter: &Counter,
+        _cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], SadPathSigGroups)> {
+        unimplemented!();
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SadPathSigGroup {
+    pub siger: Siger,
+}
+
+impl SadPathSigGroup {
+    pub fn new(siger: Siger) -> Self {
+        Self { siger }
+    }
+}
+
+impl GroupItem for SadPathSigGroup {
+    fn qb64(&self) -> ParsideResult<String> {
+        self.siger.qb64().map_err(ParsideError::from)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb64b().map_err(ParsideError::from)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb2().map_err(ParsideError::from)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.siger.full_size()?;
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/groups/seal_source_couples.rs
+++ b/src/cesr/parside/message/groups/seal_source_couples.rs
@@ -1,0 +1,90 @@
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Matter, Saider, Seqner};
+use nom::multi::count;
+use nom::sequence::tuple;
+
+#[derive(Debug, Clone, Default)]
+pub struct SealSourceCouples {
+    pub value: Vec<SealSourceCouple>,
+}
+
+impl Group<SealSourceCouple> for SealSourceCouples {
+    const CODE: &'static str = Codex::SealSourceCouples;
+
+    fn new(value: Vec<SealSourceCouple>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<SealSourceCouple> {
+        &self.value
+    }
+}
+
+impl SealSourceCouples {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], SealSourceCouples)> {
+        let (rest, body) = count(
+            tuple((Parsers::seqner_parser(cold_code)?, Parsers::saider_parser(cold_code)?)),
+            counter.count() as usize,
+        )(bytes)?;
+        let body =
+            body.into_iter().map(|(seqner, saider)| SealSourceCouple { seqner, saider }).collect();
+
+        Ok((rest, SealSourceCouples { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SealSourceCouple {
+    pub seqner: Seqner,
+    pub saider: Saider,
+}
+
+impl SealSourceCouple {
+    pub fn new(seqner: Seqner, saider: Saider) -> Self {
+        Self { seqner, saider }
+    }
+}
+
+impl GroupItem for SealSourceCouple {
+    fn qb64(&self) -> ParsideResult<String> {
+        let mut out = String::new();
+        out += &self.seqner.qb64()?;
+        out += &self.saider.qb64()?;
+        Ok(out)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()?];
+        let mut offset = 0;
+        let mut len = self.seqner.full_size()?;
+        out[offset..len].copy_from_slice(&self.seqner.qb64b()?);
+        offset += len;
+        len = self.saider.full_size()?;
+        out[offset..len].copy_from_slice(&self.saider.qb64b()?);
+        Ok(out)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()? / 4 * 3];
+        let mut offset = 0;
+        let mut len = self.seqner.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.seqner.qb2()?);
+        offset += len;
+        len = self.saider.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.saider.qb2()?);
+        Ok(out)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.seqner.full_size()? + self.saider.full_size()?;
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/groups/trans_idx_sig_groups.rs
+++ b/src/cesr/parside/message/groups/trans_idx_sig_groups.rs
@@ -1,0 +1,186 @@
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::controller_idx_sigs::ControllerIdxSig;
+use crate::cesr::parside::message::groups::controller_idx_sigs::ControllerIdxSigs;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Matter, Saider, Seqner};
+use nom::multi::count;
+use nom::sequence::tuple;
+use crate::prefexing::prefixer::Prefixer;
+
+#[derive(Debug, Clone, Default)]
+pub struct TransIdxSigGroups {
+    pub value: Vec<TransIdxSigGroup>,
+}
+
+impl Group<TransIdxSigGroup> for TransIdxSigGroups {
+    const CODE: &'static str = Codex::TransIdxSigGroups;
+
+    fn new(value: Vec<TransIdxSigGroup>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<TransIdxSigGroup> {
+        &self.value
+    }
+}
+
+impl TransIdxSigGroups {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], TransIdxSigGroups)> {
+        let (rest, body) = count(
+            tuple((
+                Parsers::prefixer_parser(cold_code)?,
+                Parsers::seqner_parser(cold_code)?,
+                Parsers::saider_parser(cold_code)?,
+                Parsers::siger_list_parser(cold_code)?,
+            )),
+            counter.count() as usize,
+        )(bytes)?;
+
+        let body = body
+            .into_iter()
+            .map(|(prefixer, seqner, saider, isigers)| TransIdxSigGroup {
+                prefixer,
+                seqner,
+                saider,
+                isigers: ControllerIdxSigs::new(
+                    isigers.into_iter().map(ControllerIdxSig::new).collect(),
+                ),
+            })
+            .collect();
+
+        Ok((rest, TransIdxSigGroups { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TransIdxSigGroup {
+    pub prefixer: Prefixer,
+    pub seqner: Seqner,
+    pub saider: Saider,
+    pub isigers: ControllerIdxSigs,
+}
+
+impl TransIdxSigGroup {
+    pub fn new(
+        prefixer: Prefixer,
+        seqner: Seqner,
+        saider: Saider,
+        isigers: ControllerIdxSigs,
+    ) -> Self {
+        Self { prefixer, seqner, saider, isigers }
+    }
+
+    fn counter() -> ParsideResult<Counter> {
+        Ok(Counter::new_with_code_and_count(Codex::TransIdxSigGroups, 1)?)
+    }
+}
+
+impl GroupItem for TransIdxSigGroup {
+    fn qb64(&self) -> ParsideResult<String> {
+        let counter = Self::counter()?;
+
+        let mut out = "\0".repeat(self.full_size()?);
+        let mut start = 0;
+        let mut end = counter.full_size()?;
+
+        unsafe { out[start..end].as_bytes_mut() }.copy_from_slice(counter.qb64()?.as_bytes());
+        start = end;
+        end += self.prefixer.full_size()?;
+        unsafe { out[start..end].as_bytes_mut() }.copy_from_slice(self.prefixer.qb64()?.as_bytes());
+        start = end;
+        end += self.seqner.full_size()?;
+        unsafe { out[start..end].as_bytes_mut() }.copy_from_slice(self.seqner.qb64()?.as_bytes());
+        start = end;
+        end += self.saider.full_size()?;
+        unsafe { out[start..end].as_bytes_mut() }.copy_from_slice(self.saider.qb64()?.as_bytes());
+        start = end;
+        end += self.isigers.full_size()?;
+        unsafe { out[start..end].as_bytes_mut() }.copy_from_slice(self.isigers.qb64()?.as_bytes());
+
+        Ok(out)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let counter = Self::counter()?;
+
+        let mut out = vec![0u8; self.full_size()?];
+        let mut start = 0;
+        let mut end = counter.full_size()?;
+
+        out[start..end].copy_from_slice(&counter.qb64b()?);
+        start = end;
+        end += self.prefixer.full_size()?;
+        out[start..end].copy_from_slice(&self.prefixer.qb64b()?);
+        start = end;
+        end += self.seqner.full_size()?;
+        out[start..end].copy_from_slice(&self.seqner.qb64b()?);
+        start = end;
+        end += self.saider.full_size()?;
+        out[start..end].copy_from_slice(&self.saider.qb64b()?);
+        start = end;
+        end += self.isigers.full_size()?;
+        out[start..end].copy_from_slice(&self.isigers.qb64b()?);
+
+        Ok(out)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let counter = Self::counter()?;
+
+        let mut out = vec![0u8; self.full_size()? / 4 * 3];
+        let mut start = 0;
+        let mut end = counter.full_size()?;
+
+        out[start..end].copy_from_slice(&counter.qb2()?);
+        start = end;
+        end += self.prefixer.full_size()? / 4 * 3;
+        out[start..end].copy_from_slice(&self.prefixer.qb2()?);
+        start = end;
+        end += self.seqner.full_size()? / 4 * 3;
+        out[start..end].copy_from_slice(&self.seqner.qb2()?);
+        start = end;
+        end += self.saider.full_size()? / 4 * 3;
+        out[start..end].copy_from_slice(&self.saider.qb2()?);
+        start = end;
+        end += self.isigers.full_size()? / 4 * 3;
+        out[start..end].copy_from_slice(&self.isigers.qb2()?);
+        Ok(out)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = Self::counter()?.full_size()?
+            + self.prefixer.full_size()?
+            + self.seqner.full_size()?
+            + self.saider.full_size()?
+            + self.isigers.full_size()?;
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    pub use crate::cesr::matter::Codex as MatterCodex;
+
+    #[test]
+    pub fn test_parse_trans_idx_sig_groups() {
+        let stream = br#"EFhg5my9DuMU6gw1CVk6QgkmZKBttWSXDzVzWVmxh0_K0AAAAAAAAAAAAAAAAAAAAAAAEFhg5my9DuMU6gw1CVk6QgkmZKBttWSXDzVzWVmxh0_K-AABAADghKct9eYTuSgSd5wdPSYG06tGX7ZRp_BDnrgbSxJpsJtrA-fP7Pa1W602gHeMrO6HZsD1z3tWV5jGlApFmVIB"#;
+
+        let counter =
+            Counter::new(Some(1), None, Some(TransIdxSigGroups::CODE), None, None, None).unwrap();
+        let (rest, group) =
+            TransIdxSigGroups::from_stream_bytes(stream, &counter, &ColdCode::CtB64).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(1, group.value.len());
+        assert_eq!(MatterCodex::Blake3_256.to_string(), group.value[0].prefixer.code());
+        assert_eq!(MatterCodex::Salt_128.to_string(), group.value[0].seqner.code());
+        assert_eq!(MatterCodex::Blake3_256.to_string(), group.value[0].saider.code());
+    }
+}

--- a/src/cesr/parside/message/groups/trans_last_idx_sig_groups.rs
+++ b/src/cesr/parside/message/groups/trans_last_idx_sig_groups.rs
@@ -1,0 +1,126 @@
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::controller_idx_sigs::ControllerIdxSig;
+use crate::cesr::parside::message::groups::controller_idx_sigs::ControllerIdxSigs;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Matter};
+use nom::multi::count;
+use nom::sequence::tuple;
+use crate::prefexing::prefixer::Prefixer;
+
+#[derive(Debug, Clone, Default)]
+pub struct TransLastIdxSigGroups {
+    pub value: Vec<TransLastIdxSigGroup>,
+}
+
+impl Group<TransLastIdxSigGroup> for TransLastIdxSigGroups {
+    const CODE: &'static str = Codex::TransLastIdxSigGroups;
+
+    fn new(value: Vec<TransLastIdxSigGroup>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<TransLastIdxSigGroup> {
+        &self.value
+    }
+}
+
+impl TransLastIdxSigGroups {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], TransLastIdxSigGroups)> {
+        let (rest, body) = count(
+            tuple((Parsers::prefixer_parser(cold_code)?, Parsers::siger_list_parser(cold_code)?)),
+            counter.count() as usize,
+        )(bytes)?;
+
+        let body = body
+            .into_iter()
+            .map(|(prefixer, isigers)| TransLastIdxSigGroup {
+                prefixer,
+                isigers: ControllerIdxSigs::new(
+                    isigers.into_iter().map(ControllerIdxSig::new).collect(),
+                ),
+            })
+            .collect();
+
+        Ok((rest, TransLastIdxSigGroups { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TransLastIdxSigGroup {
+    pub prefixer: Prefixer,
+    pub isigers: ControllerIdxSigs,
+}
+
+impl TransLastIdxSigGroup {
+    pub fn new(prefixer: Prefixer, isigers: ControllerIdxSigs) -> Self {
+        Self { prefixer, isigers }
+    }
+}
+
+impl GroupItem for TransLastIdxSigGroup {
+    fn qb64(&self) -> ParsideResult<String> {
+        let mut out = "\0".repeat(self.full_size()?);
+        let mut offset = 0;
+        let mut len = self.prefixer.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }
+            .copy_from_slice(self.prefixer.qb64()?.as_bytes());
+        offset += len;
+        len = self.isigers.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }.copy_from_slice(self.isigers.qb64()?.as_bytes());
+        Ok(out)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()?];
+        let mut offset = 0;
+        let mut len = self.prefixer.full_size()?;
+        out[offset..len].copy_from_slice(&self.prefixer.qb64b()?);
+        offset += len;
+        len = self.isigers.full_size()?;
+        out[offset..len].copy_from_slice(&self.isigers.qb64b()?);
+        Ok(out)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()? / 4 * 3];
+        let mut offset = 0;
+        let mut len = self.prefixer.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.prefixer.qb2()?);
+        offset += len;
+        len = self.isigers.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.isigers.qb2()?);
+        Ok(out)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.prefixer.full_size()? + self.isigers.full_size()?;
+        Ok(size)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    pub use crate::cesr::matter::Codex as MatterCodex;
+
+    #[test]
+    pub fn test_parse_trans_last_idx_sig_groups() {
+        let stream = br#"EB1f36VmoizOIpBIBv3X4ZiWJQWjtKJ7TMmsZltT0B32-AABAAAKB9u6wyLS9kl_iGVGCqrs-3XqFbyGeOKuiOEA9JZpxI9GMv0GJv2wbY1-sOD_HOJcvXO7LSO8g8MSeRXjtL4I"#;
+
+        let counter =
+            Counter::new(Some(1), None, Some(TransLastIdxSigGroups::CODE), None, None, None)
+                .unwrap();
+        let (rest, group) =
+            TransLastIdxSigGroups::from_stream_bytes(stream, &counter, &ColdCode::CtB64).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(1, group.value.len());
+        assert_eq!(MatterCodex::Blake3_256.to_string(), group.value[0].prefixer.code());
+    }
+}

--- a/src/cesr/parside/message/groups/trans_receipt_quadruples.rs
+++ b/src/cesr/parside/message/groups/trans_receipt_quadruples.rs
@@ -1,0 +1,131 @@
+use crate::cesr::parside::error::ParsideResult;
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Indexer, Matter, Saider, Seqner, Siger};
+use nom::multi::count;
+use nom::sequence::tuple;
+use crate::prefexing::prefixer::Prefixer;
+
+#[derive(Debug, Clone, Default)]
+pub struct TransReceiptQuadruples {
+    pub value: Vec<TransReceiptQuadruple>,
+}
+
+impl Group<TransReceiptQuadruple> for TransReceiptQuadruples {
+    const CODE: &'static str = Codex::TransReceiptQuadruples;
+
+    fn new(value: Vec<TransReceiptQuadruple>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<TransReceiptQuadruple> {
+        &self.value
+    }
+}
+
+impl TransReceiptQuadruples {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], TransReceiptQuadruples)> {
+        let (rest, body) = count(
+            tuple((
+                Parsers::prefixer_parser(cold_code)?,
+                Parsers::seqner_parser(cold_code)?,
+                Parsers::saider_parser(cold_code)?,
+                Parsers::siger_parser(cold_code)?,
+            )),
+            counter.count() as usize,
+        )(bytes)?;
+        let body = body
+            .into_iter()
+            .map(|(prefixer, seqner, saider, siger)| TransReceiptQuadruple {
+                prefixer,
+                seqner,
+                saider,
+                siger,
+            })
+            .collect();
+
+        Ok((rest, TransReceiptQuadruples { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TransReceiptQuadruple {
+    pub prefixer: Prefixer,
+    pub seqner: Seqner,
+    pub saider: Saider,
+    pub siger: Siger,
+}
+
+impl TransReceiptQuadruple {
+    pub fn new(prefixer: Prefixer, seqner: Seqner, saider: Saider, siger: Siger) -> Self {
+        Self { prefixer, seqner, saider, siger }
+    }
+}
+
+impl GroupItem for TransReceiptQuadruple {
+    fn qb64(&self) -> ParsideResult<String> {
+        let mut out = "\0".repeat(self.full_size()?);
+        let mut offset = 0;
+        let mut len = self.prefixer.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }
+            .copy_from_slice(self.prefixer.qb64()?.as_bytes());
+        offset += len;
+        len = self.seqner.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }.copy_from_slice(self.seqner.qb64()?.as_bytes());
+        offset += len;
+        len = self.saider.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }.copy_from_slice(self.saider.qb64()?.as_bytes());
+        offset += len;
+        len = self.siger.full_size()?;
+        unsafe { out[offset..len].as_bytes_mut() }.copy_from_slice(self.siger.qb64()?.as_bytes());
+        Ok(out)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()?];
+        let mut offset = 0;
+        let mut len = self.prefixer.full_size()?;
+        out[offset..len].copy_from_slice(&self.prefixer.qb64b()?);
+        offset += len;
+        len = self.seqner.full_size()?;
+        out[offset..len].copy_from_slice(&self.seqner.qb64b()?);
+        offset += len;
+        len = self.saider.full_size()?;
+        out[offset..len].copy_from_slice(&self.saider.qb64b()?);
+        offset += len;
+        len = self.siger.full_size()?;
+        out[offset..len].copy_from_slice(&self.siger.qb64b()?);
+        Ok(out)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        let mut out = vec![0u8; self.full_size()? / 4 * 3];
+        let mut offset = 0;
+        let mut len = self.prefixer.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.prefixer.qb2()?);
+        offset += len;
+        len = self.seqner.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.seqner.qb2()?);
+        offset += len;
+        len = self.saider.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.saider.qb2()?);
+        offset += len;
+        len = self.siger.full_size()? / 4 * 3;
+        out[offset..len].copy_from_slice(&self.siger.qb2()?);
+        Ok(out)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.prefixer.full_size()?
+            + self.seqner.full_size()?
+            + self.saider.full_size()?
+            + self.siger.full_size()?;
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/groups/witness_idx_sigs.rs
+++ b/src/cesr/parside/message/groups/witness_idx_sigs.rs
@@ -1,0 +1,67 @@
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::parsers::Parsers;
+use crate::cesr::parside::message::{Group, GroupItem};
+use crate::cesr::counter::Codex;
+use crate::cesr::{Counter, Indexer, Siger};
+use nom::multi::count;
+
+#[derive(Debug, Clone, Default)]
+pub struct WitnessIdxSigs {
+    pub value: Vec<WitnessIdxSig>,
+}
+
+impl Group<WitnessIdxSig> for WitnessIdxSigs {
+    const CODE: &'static str = Codex::WitnessIdxSigs;
+
+    fn new(value: Vec<WitnessIdxSig>) -> Self {
+        Self { value }
+    }
+
+    fn value(&self) -> &Vec<WitnessIdxSig> {
+        &self.value
+    }
+}
+
+impl WitnessIdxSigs {
+    pub(crate) fn from_stream_bytes<'a>(
+        bytes: &'a [u8],
+        counter: &Counter,
+        cold_code: &ColdCode,
+    ) -> ParsideResult<(&'a [u8], WitnessIdxSigs)> {
+        let (rest, body) =
+            count(Parsers::siger_parser(cold_code)?, counter.count() as usize)(bytes)?;
+        let body = body.into_iter().map(|siger| WitnessIdxSig { siger }).collect();
+        Ok((rest, WitnessIdxSigs { value: body }))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WitnessIdxSig {
+    pub siger: Siger,
+}
+
+impl WitnessIdxSig {
+    pub fn new(siger: Siger) -> Self {
+        Self { siger }
+    }
+}
+
+impl GroupItem for WitnessIdxSig {
+    fn qb64(&self) -> ParsideResult<String> {
+        self.siger.qb64().map_err(ParsideError::from)
+    }
+
+    fn qb64b(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb64b().map_err(ParsideError::from)
+    }
+
+    fn qb2(&self) -> ParsideResult<Vec<u8>> {
+        self.siger.qb2().map_err(ParsideError::from)
+    }
+
+    fn full_size(&self) -> ParsideResult<usize> {
+        let size = self.siger.full_size()?;
+        Ok(size)
+    }
+}

--- a/src/cesr/parside/message/message.rs
+++ b/src/cesr/parside/message/message.rs
@@ -1,0 +1,63 @@
+use serde::de::DeserializeOwned;
+
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::cesr::parside::message::custom_payload::CustomPayload;
+use crate::cesr::parside::message::groups::CesrGroup;
+
+/// Datastructures representing single parsed message which either custom payload or known CESR group
+#[derive(Debug)]
+pub enum Message {
+    Custom { value: CustomPayload },
+    Group { value: CesrGroup },
+}
+
+impl Message {
+    /// Parse single message from provided bytes
+    pub fn from_stream_bytes(bytes: &[u8]) -> ParsideResult<(&[u8], Message)> {
+        if bytes.is_empty() {
+            return Err(ParsideError::EmptyBytesStream);
+        }
+
+        let cold_code = ColdCode::try_from(bytes[0])?;
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::CtOpB2 | ColdCode::OpB64 => {
+                CesrGroup::from_stream_bytes(bytes)
+                    .map(|(rest, value)| (rest, Message::Group { value }))
+            }
+            ColdCode::Json => CustomPayload::from_json_stream(bytes)
+                .map(|(rest, value)| (rest, Message::Custom { value })),
+            ColdCode::Cbor => CustomPayload::from_cbor_stream(bytes)
+                .map(|(rest, value)| (rest, Message::Custom { value })),
+            ColdCode::MGPK1 | ColdCode::MGPK2 => CustomPayload::from_mgpk_stream(bytes)
+                .map(|(rest, value)| (rest, Message::Custom { value })),
+            ColdCode::Free => {
+                Err(ParsideError::Unexpected(format!("Unsupported cold code {}", bytes[0])))
+            }
+        }
+    }
+
+    /// Get custom payload from parsed message
+    pub fn payload(&self) -> ParsideResult<&CustomPayload> {
+        match self {
+            Message::Group { .. } => Err(ParsideError::NotExist),
+            Message::Custom { value } => Ok(value),
+        }
+    }
+
+    /// Get custom payload converted to specific data type from parsed message
+    pub fn typed_payload<D: DeserializeOwned>(&self) -> ParsideResult<D> {
+        match self {
+            Message::Group { .. } => Err(ParsideError::NotExist),
+            Message::Custom { value } => value.to_typed_message::<D>(),
+        }
+    }
+
+    /// Get CESR group from parsed message
+    pub fn cesr_group(&self) -> ParsideResult<&CesrGroup> {
+        match self {
+            Message::Group { value } => Ok(value),
+            Message::Custom { .. } => Err(ParsideError::NotExist),
+        }
+    }
+}

--- a/src/cesr/parside/message/message_list.rs
+++ b/src/cesr/parside/message/message_list.rs
@@ -1,0 +1,105 @@
+use nom::multi::many0;
+
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::{nomify};
+use crate::cesr::parside::Message;
+
+/// Datastructures representing list of parsed messages
+#[derive(Debug)]
+pub struct MessageList {
+    pub messages: Vec<Message>,
+}
+
+impl MessageList {
+    /// Parse multiple messages from provided bytes
+    pub fn from_stream_bytes<'a>(bytes: &'a [u8]) -> ParsideResult<(&'a [u8], MessageList)> {
+        if bytes.is_empty() {
+            return Err(ParsideError::EmptyBytesStream);
+        }
+        let (rest, messages) = many0(nomify!(Message::from_stream_bytes))(bytes)?;
+        Ok((rest, MessageList { messages }))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::cesr::parside::error::ParsideError;
+    use crate::cesr::parside::CesrGroup;
+
+    const PAYLOAD_1: &'static str = r#"{"v":"1","t":"foo"}"#;
+    const PAYLOAD_2: &'static str = r#"{"v":"2","t":"bla"}"#;
+    const NON_TRANS_RECEIPT_COUPLES: &'static str = r#"-CABBD8-gMSJ6K1PQ7_gG5ZJn2NkHQJgdkiNrTBz_FWWS_cC0BDc1i44ZX0jaIHh5oNDx-TITbPnI6VEn2nKlqPwkkTF452X7XxYh80tolDpReYwZpnD8TF4Or2v3CpSCikyt6EG"#;
+    const CONTROLLER_IDX_SIGS: &'static str = r#"-AABAABg3q8uNg1A2jhEAdbKGf-QupQhNnmZQx3zIyPLWBe6qqLT5ynytivf9EwJhxyhy87a0x2cezDdil4SsM2xxs0O"#;
+    const REST: &'static str = "rest";
+
+    #[test]
+    pub fn test_parse_message_list_with_empty_bytes() {
+        let err = MessageList::from_stream_bytes(&[]).unwrap_err();
+        assert_eq!(err, ParsideError::EmptyBytesStream);
+    }
+
+    #[test]
+    pub fn test_parse_message_list_does_not_containing_messages() {
+        let stream = format!("{}", REST);
+        let (rest, message_list) = MessageList::from_stream_bytes(stream.as_bytes()).unwrap();
+        assert!(!rest.is_empty());
+        assert_eq!(REST.as_bytes(), rest);
+        assert_eq!(0, message_list.messages.len());
+    }
+
+    #[test]
+    pub fn test_parse_message_list_containing_single_generic_payload() {
+        let stream = format!("{}", PAYLOAD_1);
+        let (rest, message_list) = MessageList::from_stream_bytes(stream.as_bytes()).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(1, message_list.messages.len());
+        assert!(matches!(message_list.messages[0], Message::Custom { .. }));
+    }
+
+    #[test]
+    pub fn test_parse_message_list_containing_single_cesr_group() {
+        let stream = format!("{}", NON_TRANS_RECEIPT_COUPLES);
+        let (rest, message_list) = MessageList::from_stream_bytes(stream.as_bytes()).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(1, message_list.messages.len());
+        assert!(matches!(
+            message_list.messages[0],
+            Message::Group { value: CesrGroup::NonTransReceiptCouplesVariant { .. } }
+        ));
+    }
+
+    #[test]
+    pub fn test_parse_message_list_containing_multiple_message() {
+        let stream = format!(
+            "{}{}{}{}",
+            PAYLOAD_1, NON_TRANS_RECEIPT_COUPLES, PAYLOAD_2, CONTROLLER_IDX_SIGS
+        );
+        let (rest, message_list) = MessageList::from_stream_bytes(stream.as_bytes()).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(4, message_list.messages.len());
+        assert!(matches!(message_list.messages[0], Message::Custom { .. }));
+        assert!(matches!(
+            message_list.messages[1],
+            Message::Group { value: CesrGroup::NonTransReceiptCouplesVariant { .. } }
+        ));
+        assert!(matches!(message_list.messages[2], Message::Custom { .. }));
+        assert!(matches!(
+            message_list.messages[3],
+            Message::Group { value: CesrGroup::ControllerIdxSigsVariant { .. } }
+        ));
+    }
+
+    #[test]
+    pub fn test_parse_message_list_containing_multiple_message_with_rest_bytes() {
+        let stream = format!("{}{}{}", PAYLOAD_1, NON_TRANS_RECEIPT_COUPLES, REST);
+        let (rest, message_list) = MessageList::from_stream_bytes(stream.as_bytes()).unwrap();
+        assert!(!rest.is_empty());
+        assert_eq!(2, message_list.messages.len());
+        assert!(matches!(message_list.messages[0], Message::Custom { .. }));
+        assert!(matches!(
+            message_list.messages[1],
+            Message::Group { value: CesrGroup::NonTransReceiptCouplesVariant { .. } }
+        ));
+    }
+}

--- a/src/cesr/parside/message/mod.rs
+++ b/src/cesr/parside/message/mod.rs
@@ -1,0 +1,12 @@
+pub mod cold_code;
+pub mod custom_payload;
+pub mod groups;
+#[allow(clippy::module_inception)]
+pub mod message;
+pub mod message_list;
+mod parsers;
+
+pub use custom_payload::CustomPayload;
+pub use groups::*;
+pub use message::Message;
+pub use message_list::MessageList;

--- a/src/cesr/parside/message/parsers.rs
+++ b/src/cesr/parside/message/parsers.rs
@@ -1,0 +1,231 @@
+use crate::cesr::parside::error::{ParsideError, ParsideResult};
+use crate::cesr::parside::message::cold_code::ColdCode;
+use crate::nomify;
+use crate::cesr::{
+    Cigar, Counter, Dater, Diger, Indexer, Matter, Saider, Seqner, Siger, Verfer,
+};
+use nom::multi::count;
+use crate::pathing::pather::Pather;
+use crate::prefexing::prefixer::Prefixer;
+
+/// Parser's of CESR primitives
+pub struct Parsers {}
+
+pub type ParserRet<'a, T> = fn(&'a [u8]) -> nom::IResult<&'a [u8], T>;
+
+impl Parsers {
+    pub(crate) fn pather_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Pather>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::pather_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::pather_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn pather_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Pather)> {
+        let matter = (Pather::new_with_qb64b)(bytes)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn pather_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Pather)> {
+        let matter = (Pather::new_with_qb2)(bytes)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    #[allow(unused)]
+    pub(crate) fn diger_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Diger>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::diger_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::diger_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn diger_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Diger)> {
+        let matter = (Diger::new_with_qb64b)(bytes)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn diger_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Diger)> {
+        let matter = (Diger::new_with_qb2)(bytes)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    pub(crate) fn siger_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Siger>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::siger_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::siger_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn siger_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Siger)> {
+        let matter = Siger::new_with_qb64b(bytes, None)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn siger_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Siger)> {
+        let matter = Siger::new_with_qb2(bytes, None)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    pub(crate) fn cigar_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Cigar>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::cigar_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::cigar_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn cigar_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Cigar)> {
+        let verfer = Verfer::new_with_qb64b(bytes)?;
+        let size = verfer.full_size()?;
+        let bytes = &bytes[size..];
+        let cigar = Cigar::new_with_qb64b(bytes, Some(&verfer))?;
+        let size = cigar.full_size()?;
+        Ok((&bytes[size..], cigar))
+    }
+
+    fn cigar_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Cigar)> {
+        let verfer = Verfer::new_with_qb2(bytes)?;
+        let size = verfer.full_size()? / 4 * 3;
+        let bytes = &bytes[size..];
+        let cigar = Cigar::new_with_qb2(bytes, Some(&verfer))?;
+        let size = cigar.full_size()? / 4 * 3;
+        Ok((&bytes[size..], cigar))
+    }
+
+    pub(crate) fn prefixer_parser<'a>(
+        cold_code: &ColdCode,
+    ) -> ParsideResult<ParserRet<'a, Prefixer>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::prefixer_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::prefixer_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn prefixer_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Prefixer)> {
+        let matter = (Prefixer::new_with_qb64b)(bytes)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn prefixer_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Prefixer)> {
+        let matter = (Prefixer::new_with_qb2)(bytes)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    pub(crate) fn seqner_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Seqner>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::seqner_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::seqner_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn seqner_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Seqner)> {
+        let matter = (Seqner::new_with_qb64b)(bytes)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn seqner_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Seqner)> {
+        let matter = (Seqner::new_with_qb2)(bytes)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    pub(crate) fn dater_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Dater>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::dater_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::dater_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn dater_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Dater)> {
+        let matter = (Dater::new_with_qb64b)(bytes)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn dater_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Dater)> {
+        let matter = (Dater::new_with_qb2)(bytes)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    pub(crate) fn saider_parser<'a>(cold_code: &ColdCode) -> ParsideResult<ParserRet<'a, Saider>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::saider_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::saider_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn saider_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Saider)> {
+        let matter = (Saider::new_with_qb64b)(bytes)?;
+        let size = matter.full_size()?;
+        Ok((&bytes[size..], matter))
+    }
+
+    fn saider_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Saider)> {
+        let matter = (Saider::new_with_qb2)(bytes)?;
+        let size = matter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], matter))
+    }
+
+    pub(crate) fn counter_parser<'a>(
+        cold_code: &ColdCode,
+    ) -> ParsideResult<ParserRet<'a, Counter>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::counter_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::counter_from_qb2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn counter_from_qb64b(bytes: &[u8]) -> ParsideResult<(&[u8], Counter)> {
+        let counter = Counter::new(None, None, None, Some(bytes), None, None)?;
+        let size = counter.full_size()?;
+        Ok((&bytes[size..], counter))
+    }
+
+    fn counter_from_qb2(bytes: &[u8]) -> ParsideResult<(&[u8], Counter)> {
+        let counter = Counter::new(None, None, None, None, None, Some(bytes))?;
+        let size = counter.full_size()? / 4 * 3;
+        Ok((&bytes[size..], counter))
+    }
+
+    pub(crate) fn siger_list_parser<'a>(
+        cold_code: &ColdCode,
+    ) -> ParsideResult<ParserRet<'a, Vec<Siger>>> {
+        match cold_code {
+            ColdCode::CtB64 | ColdCode::OpB64 => Ok(nomify!(Self::siger_list_from_qb64b)),
+            ColdCode::CtOpB2 => Ok(nomify!(Self::siger_list_from_q2)),
+            _ => Err(ParsideError::Unexpected("Unexpected cold code".to_string())),
+        }
+    }
+
+    fn siger_list_from_qb64b<'a>(bytes: &'a [u8]) -> ParsideResult<(&'a [u8], Vec<Siger>)> {
+        let (rest, counter) = Self::counter_from_qb64b(bytes)?;
+        let (rest, values) =
+            count(nomify!(Parsers::siger_from_qb64b), counter.count() as usize)(rest)?;
+        Ok((rest, values))
+    }
+
+    fn siger_list_from_q2<'a>(bytes: &'a [u8]) -> ParsideResult<(&'a [u8], Vec<Siger>)> {
+        let (rest, counter) = Parsers::counter_from_qb2(bytes)?;
+        let (rest, values) =
+            count(nomify!(Parsers::siger_from_qb2), counter.count() as usize)(rest)?;
+        Ok((rest, values))
+    }
+}

--- a/src/cesr/parside/mod.rs
+++ b/src/cesr/parside/mod.rs
@@ -1,0 +1,6 @@
+#![allow(unused_imports)]
+pub mod error;
+pub mod message;
+mod utils;
+
+pub use message::{CesrGroup, CustomPayload, Group, Message, MessageList};

--- a/src/cesr/parside/utils/mod.rs
+++ b/src/cesr/parside/utils/mod.rs
@@ -1,0 +1,2 @@
+#[macro_use]
+pub mod nom;

--- a/src/cesr/parside/utils/nom.rs
+++ b/src/cesr/parside/utils/nom.rs
@@ -1,0 +1,11 @@
+// Helper macros to map function returning parside result to nom compatible
+#[macro_export]
+macro_rules! nomify {
+    ($func:expr) => {
+        |bytes: &'a [u8]| {
+            $func(bytes).map_err(|_| {
+                nom::Err::Error(nom::error::Error::new(bytes, nom::error::ErrorKind::IsNot))
+            })
+        }
+    };
+}


### PR DESCRIPTION
To speed up development I am temporarily adding in all of the Parside code to make it easy to develop while I bulid spec compliance and a complete agent setup inside of KERIde. Once spec compliance is achieved, as well as a KERIA-like agent, Signify, and a did:webs implementation, then, I will consider splitting everything back out into separate libraries.